### PR TITLE
Add basic learning plan generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Learning Sprint Framework
 
 A framework for structuring 2-week learning sprints with daily progress tracking.
+When creating a sprint the API now auto-generates a simple two-week plan so you know what to focus on each day.
 
 ## Core Concepts
 

--- a/api/src/routes/learning-path.ts
+++ b/api/src/routes/learning-path.ts
@@ -5,13 +5,15 @@ import { db } from '../services/db'
 import { sprints, dailyProgress, sprintStats } from '../services/db/schema'
 import { and, eq, desc } from 'drizzle-orm'
 import { generateSprintSlug } from '../services/llm/utils'
+import { generateInitialPlan } from '../services/scheduling/allocation'
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth'
 
 const CreateSprintSchema = z.object({
   title: z.string().min(1),
   startDate: z.string(),
   endDate: z.string(),
-  goalDescription: z.string().min(1)
+  goalDescription: z.string().min(1),
+  timePerDay: z.number().min(0.5).max(24).optional()
 })
 
 const app = new Hono()
@@ -28,6 +30,16 @@ app.post('/', async (c) => {
     }
 
     const body = CreateSprintSchema.parse(await c.req.json())
+    const timePerDay = body.timePerDay ?? 2
+
+    const plan = generateInitialPlan({
+      title: body.title,
+      goalDescription: body.goalDescription,
+      finalDeliverable: body.goalDescription,
+      startDate: new Date(body.startDate),
+      endDate: new Date(body.endDate),
+      timePerDay
+    })
 
     // Create sprint
     const [sprint] = await db
@@ -38,7 +50,8 @@ app.post('/', async (c) => {
         goalDescription: body.goalDescription,
         startDate: new Date(body.startDate),
         endDate: new Date(body.endDate),
-        slug: generateSprintSlug()
+        slug: generateSprintSlug(),
+        learningPlan: plan
       })
       .returning()
 
@@ -103,7 +116,8 @@ app.get('/:slug', async (c) => {
         currentStreak: sprint.stats?.currentStreak ?? 0,
         longestStreak: sprint.stats?.longestStreak ?? 0,
         lastProgressDate: sprint.stats?.lastProgressDate ?? null
-      }
+      },
+      learningPlan: sprint.learningPlan
     }
 
     return c.json({ success: true, sprint: response })
@@ -141,7 +155,8 @@ app.get('/', async (c) => {
         currentStreak: sprint.stats?.currentStreak ?? 0,
         longestStreak: sprint.stats?.longestStreak ?? 0,
         lastProgressDate: sprint.stats?.lastProgressDate ?? null
-      }
+      },
+      learningPlan: sprint.learningPlan
     }))
 
     return c.json({ success: true, sprints: response })

--- a/api/src/services/db/schema.ts
+++ b/api/src/services/db/schema.ts
@@ -25,6 +25,7 @@ export const sprints = pgTable('sprints', {
   goalDescription: text('goal_description').notNull(),
   startDate: timestamp('start_date').notNull(),
   endDate: timestamp('end_date').notNull(),
+  learningPlan: jsonb('learning_plan').$type<any>().default(sql`'[]'::jsonb`).notNull(),
   status: sprintStatusEnum('status').notNull().default('active'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()

--- a/web/src/app/dashboard/create-modal.tsx
+++ b/web/src/app/dashboard/create-modal.tsx
@@ -44,7 +44,8 @@ export function CreateModal({ userId }: CreateModalProps) {
           title,
           goalDescription,
           startDate: startDate.toISOString(),
-          endDate: endDate.toISOString()
+          endDate: endDate.toISOString(),
+          timePerDay: 2
         })
       })
 

--- a/web/src/app/projects/[slug]/project-details.tsx
+++ b/web/src/app/projects/[slug]/project-details.tsx
@@ -28,7 +28,11 @@ interface Project {
     timeOfDay: string[]
     effectiveness: string
     reflection: string | null
-  }>
+  }>;
+  learningPlan: Array<{
+    day: number;
+    today: { timeCommitment: number; suggestedFocus?: string };
+  }>;
 }
 
 interface ProjectDetailsProps {
@@ -200,8 +204,19 @@ export function ProjectDetails({ project, userId }: ProjectDetailsProps) {
           </Card>
         </div>
 
-        {/* Progress History */}
+        {/* Learning Plan and Progress */}
         <div className="space-y-4">
+          <Card className="p-4">
+            <h2 className="text-xl font-semibold mb-2">Two-Week Plan</h2>
+            <ul className="space-y-1 text-sm">
+              {project.learningPlan.map((item) => (
+                <li key={item.day}>
+                  Day {item.day}: {item.today.suggestedFocus || `${item.today.timeCommitment}h focus`}
+                </li>
+              ))}
+            </ul>
+          </Card>
+
           <h2 className="text-xl font-semibold">Recent Progress</h2>
           {project.dailyProgress?.slice(0, 5).map((progress, i) => (
             <Card key={i} className="p-4">

--- a/web/src/components/forms/create-project-form.tsx
+++ b/web/src/components/forms/create-project-form.tsx
@@ -38,7 +38,8 @@ export function CreateProjectForm({ userId, onSuccess, onCancel }: CreateProject
           title,
           goalDescription,
           startDate: startDate.toISOString(),
-          endDate: endDate.toISOString()
+          endDate: endDate.toISOString(),
+          timePerDay: 2
         })
       })
 


### PR DESCRIPTION
## Summary
- generate simple 2‑week plan when creating a sprint
- store plan in the `learningPlan` column
- expose the plan via API and show it on the project page
- send `timePerDay` when creating sprints

## Testing
- `npm run build` *(fails: next not found)*